### PR TITLE
travis: auto deploy content to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+cache: pip
+
+install:
+    pip install sphinx sphinx_rtd_theme
+
+script:
+    make html
+
+deploy:
+    provider: pages
+    local-dir: build/html/
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+    keep-history: true
+    fqdn: docs.anbox.io
+    on:
+        branch: master

--- a/conf.py
+++ b/conf.py
@@ -39,6 +39,7 @@ release = u''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+  'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
You need to set GITHUB_TOKEN env in travis as secure variable. Token can be got from 
https://help.github.com/articles/creating-an-access-token-for-command-line-use/

https://docs.travis-ci.com/user/deployment/pages/