### PR TITLE
docs(install): emphasize kernel installation step

### DIFF
--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -19,14 +19,25 @@ The installation of Anbox consists of two steps.
  1. Install necessary kernel modules
  2. Install the Anbox snap
 
+Install kernel modules
+^^^^^^^^^^^^^^^^^^^^^^
+
 To install the necessary kernel modules, please read :doc:`install_kernel_modules`.
 
-The second step will install the Anbox snap from the store and will give you
-everything you need to run the full Anbox experience.
+After correct installation you should have two new nodes in your systems `/dev` directory:
+
+.. code-block:: text
+
+    $ ls -1 /dev/{ashmem,binder}
+    /dev/ashmem
+    /dev/binder
 
 
 Install the Anbox snap
 ^^^^^^^^^^^^^^^^^^^^^^
+
+The second step will install the Anbox snap from the store and will give you
+everything you need to run the full Anbox experience.
 
 Installing the Anbox snap is very simple:
 


### PR DESCRIPTION
On skimming the installation page I totally missed the kernel installation step
as I directly hacked `snap install …` in my console. As a result I got very strange 
effects like non-starting application manager.

Hopefully my change emphasize the required kernel modules more clearly to
future first-time reader