### PR TITLE
Update install_kernel_modules.rst

### DIFF
--- a/userguide/install_kernel_modules.rst
+++ b/userguide/install_kernel_modules.rst
@@ -31,6 +31,13 @@ In order to add the PPA to your Ubuntu system please run the following commands:
     $ sudo apt update
     $ sudo apt install linux-headers-generic anbox-modules-dkms
 
+.. note::
+    In case `add-apt-repository` is missing, install it via:
+
+.. code-block:: text
+    
+    $ sudo apt install software-properties-common
+
 These will add the PPA to your system and install the `anbox-modules-dkms`
 package which contains the ashmem and binder kernel modules. They will be
 automatically rebuild every time the kernel packages on your system update.


### PR DESCRIPTION
On some Ubuntu-based systems (Elementary OS) PPAs are disabled by default.
The package software-properties-common needs to be manually installed.

https://github.com/anbox/anbox/pull/1336