### PR TITLE
Clarify how easy the installation can actually be

### DIFF
--- a/userguide/install.rst
+++ b/userguide/install.rst
@@ -14,15 +14,14 @@ If you don't know about snaps yet head over to `snapcraft.io <https://snapcraft.
 to get an introduction of what snaps are, how to install support for them on your
 distribution and how to use them.
 
-The installation of Anbox consists of two steps.
+On recent Ubuntu versions (>= 19.04), Anbox can be installed in just one step using `snap`.
 
- 1. Install necessary kernel modules
- 2. Install the Anbox snap
+On other systems, you may first need to install the following kernel modules.
 
 Install kernel modules
 ^^^^^^^^^^^^^^^^^^^^^^
 
-To install the necessary kernel modules, please read :doc:`install_kernel_modules`.
+Skip this step if you are running on an Ubuntu system >= 19.04. Otherwise, please follow :doc:`install_kernel_modules` to install the necessary kernel modules.
 
 After correct installation you should have two new nodes in your systems `/dev` directory:
 
@@ -36,7 +35,7 @@ After correct installation you should have two new nodes in your systems `/dev` 
 Install the Anbox snap
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The second step will install the Anbox snap from the store and will give you
+This step will install the Anbox snap from the store and will give you
 everything you need to run the full Anbox experience.
 
 Installing the Anbox snap is very simple:


### PR DESCRIPTION
I recently passed on testing Anbox in a quick moment because the installation process sounded somewhat complex ("There are two steps. Step 1: Follow this link to another page full of instructions re kernel modules"). 

Turns out, for many people there is actually only one step (`snap`) and the docs are needlessly shy about telling how easy it can be. 

This PR shows the easy path as the first thing you see in the docs (while keeping the instructions for the less easy cases prominently visible)

See also this request https://github.com/anbox/anbox/issues/2091 